### PR TITLE
feat: add database schema and DBML documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work
 tmp/
 .DS_Store
 output/
+*.log

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,11 @@ air:
 mock:
 					mockgen -build_flags=--mod=mod -destination db/mock/store.go -package mockdb github.com/Kcih4518/simpleBank/db/sqlc Store
 
-.PHONY: network postgres createdb dropdb migrateup migratedown sqlc test clean server air mock migrateup1 migratedown1
+db_docs:
+					dbdocs build doc/db.dbml
+
+db_schema:
+					dbml2sql --postgres -o doc/schema.sql doc/db.dbml
+
+
+.PHONY: network postgres createdb dropdb migrateup migratedown sqlc test clean server air mock migrateup1 migratedown1 db_docs db_schema

--- a/doc/db.dbml
+++ b/doc/db.dbml
@@ -1,0 +1,47 @@
+Table "accounts" as A {
+  "id" bigserial [pk, increment]
+  "owner" varchar [ref: > U.username,not null]
+  "balance" bigint [not null]
+  "currency" varchar [not null]
+  "created_at" timestamptz [not null, default: `now()`]
+
+  Indexes {
+    owner
+    (owner, currency) [unique]
+  }
+}
+
+Table "entries" {
+  "id" bigserial [pk, increment]
+  "account_id" bigint [not null,ref: > A.id]
+  "amount" bigint [not null, note: 'can be negative or positive']
+  "created_at" timestamptz [not null, default: `now()`]
+
+  Indexes {
+    account_id
+  }
+}
+
+Table "transfers" {
+  "id" bigserial [pk, increment]
+  "from_account_id" bigint [not null,ref: > A.id]
+  "to_account_id" bigint [not null,ref: > A.id]
+  "amount" bigint [not null, note: 'must be positive']
+  "created_at" timestamptz [not null, default: `now()`]
+
+  Indexes {
+    from_account_id
+    to_account_id
+    (from_account_id, to_account_id)
+  }
+}
+
+Table users as U {
+  username varchar [pk]
+  hashed_password varchar [not null]
+  full_name varchar [not null]
+  email varchar [unique,not null]
+  password_changed_at timestamptz [not null,default: '0001-01-01 00:00:00Z']
+  created_at timestamptz [not null,default: `now()`]
+
+}

--- a/doc/schema.sql
+++ b/doc/schema.sql
@@ -1,0 +1,59 @@
+-- SQL dump generated using DBML (dbml.dbdiagram.io)
+-- Database: PostgreSQL
+-- Generated at: 2024-07-29T13:18:10.503Z
+
+CREATE TABLE "accounts" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "owner" varchar NOT NULL,
+  "balance" bigint NOT NULL,
+  "currency" varchar NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT (now())
+);
+
+CREATE TABLE "entries" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "account_id" bigint NOT NULL,
+  "amount" bigint NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT (now())
+);
+
+CREATE TABLE "transfers" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "from_account_id" bigint NOT NULL,
+  "to_account_id" bigint NOT NULL,
+  "amount" bigint NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT (now())
+);
+
+CREATE TABLE "users" (
+  "username" varchar PRIMARY KEY,
+  "hashed_password" varchar NOT NULL,
+  "full_name" varchar NOT NULL,
+  "email" varchar UNIQUE NOT NULL,
+  "password_changed_at" timestamptz NOT NULL DEFAULT '0001-01-01 00:00:00Z',
+  "created_at" timestamptz NOT NULL DEFAULT (now())
+);
+
+CREATE INDEX ON "accounts" ("owner");
+
+CREATE UNIQUE INDEX ON "accounts" ("owner", "currency");
+
+CREATE INDEX ON "entries" ("account_id");
+
+CREATE INDEX ON "transfers" ("from_account_id");
+
+CREATE INDEX ON "transfers" ("to_account_id");
+
+CREATE INDEX ON "transfers" ("from_account_id", "to_account_id");
+
+COMMENT ON COLUMN "entries"."amount" IS 'can be negative or positive';
+
+COMMENT ON COLUMN "transfers"."amount" IS 'must be positive';
+
+ALTER TABLE "accounts" ADD FOREIGN KEY ("owner") REFERENCES "users" ("username");
+
+ALTER TABLE "entries" ADD FOREIGN KEY ("account_id") REFERENCES "accounts" ("id");
+
+ALTER TABLE "transfers" ADD FOREIGN KEY ("from_account_id") REFERENCES "accounts" ("id");
+
+ALTER TABLE "transfers" ADD FOREIGN KEY ("to_account_id") REFERENCES "accounts" ("id");


### PR DESCRIPTION
- Added `doc/schema.sql` with SQL schema for PostgreSQL database.
- Added `doc/db.dbml` with DBML representation of the database schema.
- Updated `Makefile` with `db_docs` and `db_schema` targets for generating documentation.
- Updated `.gitignore` to exclude log files.