### PR TITLE
feat: add gRPC API authorization

### DIFF
--- a/gapi/authorization.go
+++ b/gapi/authorization.go
@@ -1,0 +1,46 @@
+package gapi
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Kcih4518/simpleBank/token"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	authorizationHeader = "authorization"
+	authorizationBearer = "bearer"
+)
+
+func (server *Server) authorizeUser(ctx context.Context) (*token.Payload, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing metadata")
+	}
+
+	values := md.Get(authorizationHeader)
+	if len(values) == 0 {
+		return nil, fmt.Errorf("missing authorization header")
+	}
+
+	authHeader := values[0]
+	fields := strings.Fields(authHeader)
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("invalid authorization header format")
+	}
+
+	authType := strings.ToLower(fields[0])
+	if authType != authorizationBearer {
+		return nil, fmt.Errorf("unsupported authorization type: %s", authType)
+	}
+
+	accessToken := fields[1]
+	payload, err := server.tokenMaker.VerifyToken(accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("invalid access token: %s", err)
+	}
+	return payload, nil
+
+}

--- a/gapi/error.go
+++ b/gapi/error.go
@@ -24,3 +24,7 @@ func invalidArgumentError(violations []*errdetails.BadRequest_FieldViolation) er
 
 	return statusDetails.Err()
 }
+
+func unauthenticatedError(err error) error {
+	return status.Errorf(codes.Unauthenticated, "unauthorized: %s", err)
+}

--- a/gapi/rpc_update_user.go
+++ b/gapi/rpc_update_user.go
@@ -15,9 +15,17 @@ import (
 )
 
 func (server *Server) UpdateUser(ctx context.Context, req *pb.UpdateUserRequest) (*pb.UpdateUserResponse, error) {
+	authPayload, err := server.authorizeUser(ctx)
+	if err != nil {
+		return nil, unauthenticatedError(err)
+	}
 	violations := validateUpdateUserRequest(req)
 	if violations != nil {
 		return nil, invalidArgumentError(violations)
+	}
+
+	if authPayload.Username != req.GetUsername() {
+		return nil, status.Errorf(codes.PermissionDenied, "cannot update other user's info")
 	}
 
 	arg := db.UpdateUserParams{

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/techschool/simplebank v0.0.0-20240330095002-931b0d981595
 	go.uber.org/mock v0.4.0
 	golang.org/x/crypto v0.25.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240723171418-e6d459c13d2a

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/techschool/simplebank v0.0.0-20240330095002-931b0d981595 h1:qTep/VqUHqejgCa1Lw9jydwDHU+JiWjH5fNNqvRPjpo=
-github.com/techschool/simplebank v0.0.0-20240330095002-931b0d981595/go.mod h1:C8CRNY3wzBvK9iB0ZrRXmuiTruNESLJu0OYBqtiONjg=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=


### PR DESCRIPTION
- Implement `authorizeUser` function in `authorization.go` to handle user authorization via metadata.
- Update `UpdateUser` RPC to include authorization check.
- Add `unauthenticatedError` function in `error.go` for handling unauthorized errors.
- Remove unused dependency from `go.mod` and `go.sum`.